### PR TITLE
Update hubl_custom_module_fields.json

### DIFF
--- a/snippets/man_gen/hubl_custom_module_fields.json
+++ b/snippets/man_gen/hubl_custom_module_fields.json
@@ -9,8 +9,6 @@
       "\"sortable\": false,",
       "\"required\": false,",
       "\"locked\": false,",
-      "\"hierarchical\": false,",
-      "\"max_depth\": 0,",
       "\"children\": [${3}],",
       "\"type\": \"group\",",
       "\"default\": {} }"              
@@ -33,8 +31,6 @@
       "  \"sorting_label_field\": null,",
       "  \"default\": null",
       "},",
-      "\"hierarchical\": false,",
-      "\"max_depth\": 0,",
       "\"children\": [${3}],",
       "\"type\": \"group\",",
       "\"default\": {} }"
@@ -51,8 +47,6 @@
      "\"sortable\": false,",
      "\"required\": false,",
      "\"locked\": false,",
-     "\"hierarchical\": false,",
-     "\"max_depth\": 0,",
      "\"step\": 1,",
      "\"type\": \"date\",",
      "\"default\": ${3:null} }"
@@ -69,8 +63,6 @@
      "\"sortable\": false,",
      "\"required\": false,",
      "\"locked\": false,",
-     "\"hierarchical\": false,",
-     "\"max_depth\": 0,",
      "\"step\": 30,",
      "\"type\": \"datetime\",",
      "\"default\": ${3:null} }"
@@ -87,17 +79,16 @@
      "\"sortable\" : false,",
      "\"required\" : false,",
      "\"locked\" : false,",
-     "\"hierarchical\" : false,",
-     "\"max_depth\" : 0,",
      "\"supported_types\" : [ \"EXTERNAL\", \"CONTENT\", \"FILE\", \"EMAIL_ADDRESS\", \"BLOG\" ],",
      "\"type\" : \"link\",",
      "\"default\" : {",
-     "\"url\" : {",
-     "\"content_id\" : null,",
-     "\"type\" : \"${3|EXTERNAL,CONTENT,FILE,EMAIL_ADDRESS,BLOG|}\",",
-     "\"href\" : ${4:\"\"} },",
-     "\"open_in_new_tab\" : ${5:false,}",
-     "\"no_follow\" : false",
+     "  \"url\" : {",
+     "    \"content_id\" : null,",
+     "    \"type\" : \"${3|EXTERNAL,CONTENT,FILE,EMAIL_ADDRESS,BLOG|}\",",
+     "    \"href\" : ${4:\"\"}",
+     "  },",
+     "  \"open_in_new_tab\" : ${5:false,}",
+     "  \"no_follow\" : false",
      "} }"
     ],
     "description": "HubSpot Custom Module: Link Field"
@@ -113,11 +104,11 @@
      "\"required\" : false,",
      "\"locked\" : false,",
      "\"display\" : \"text\",",
-     "\"hierarchical\" : false,",
-     "\"max_depth\" : 0,",
      "\"step\" : 1,",
      "\"type\" : \"number\",",
-     "\"default\" : ${3:null} }"
+     "\"min\" : ${4:null},",
+     "\"max\" : ${5:null},",
+     "\"default\" : ${6:null} }"
     ],
     "description": "HubSpot Custom Module: Number Field"
   },
@@ -131,8 +122,6 @@
    "\"sortable\": false,",
    "\"required\": false,",
    "\"locked\": false,",
-   "\"hierarchical\": false,",
-   "\"max_depth\": 0,",
    "\"type\": \"richtext\",",
    "\"default\": ${3:null} }"
     ],
@@ -149,11 +138,10 @@
     "\"required\": false,",
     "\"locked\": false,",
     "\"validation_regex\": \"\",",
-    "\"hierarchical\": false,",
-    "\"max_depth\": 0,",
     "\"allow_new_line\": false,",
     "\"show_emoji_picker\": false,",
     "\"type\": \"text\",",
+    "\"placeholder\": \"\",",
     "\"default\": ${3:null} }"
     ],
     "description": "HubSpot Custom Module: Text Field"
@@ -168,8 +156,6 @@
    "\"sortable\": false,",
    "\"required\": false,",
    "\"locked\": false,",
-   "\"hierarchical\": false,",
-   "\"max_depth\": 0,",
    "\"type\": \"simplemenu\",",
    "\"default\": ${3:[]} }"
     ],
@@ -185,20 +171,18 @@
    "\"sortable\": false,",
    "\"required\": false,",
    "\"locked\": false,",
-   "\"hierarchical\": false,",
-   "\"max_depth\": 0,",
    "\"supported_types\": [",
-     "\"EXTERNAL\",",
-     "\"CONTENT\",",
-     "\"FILE\",",
-     "\"EMAIL_ADDRESS\",",
-     "\"BLOG\"",
+     "  \"EXTERNAL\",",
+     "  \"CONTENT\",",
+     "  \"FILE\",",
+     "  \"EMAIL_ADDRESS\",",
+     "  \"BLOG\"",
    "],",
    "\"type\": \"url\",",
    "\"default\": {",
-     "\"content_id\": null,",
-     "\"href\": \"\",",
-     "\"type\": \"${3|EXTERNAL,CONTENT,FILE,EMAIL_ADDRESS,BLOG|}\"} }"
+     "  \"content_id\": null,",
+     "  \"href\": \"\",",
+     "  \"type\": \"${3|EXTERNAL,CONTENT,FILE,EMAIL_ADDRESS,BLOG|}\"} }"
     ],
     "description": "HubSpot Custom Module: Url Field"
   }, 
@@ -212,8 +196,6 @@
    "\"sortable\": false,",
    "\"required\": false,",
    "\"locked\": false,",
-   "\"hierarchical\": false,",
-   "\"max_depth\": 0,",
    "\"type\": \"boolean\",",
    "\"default\": ${3:false} }"
     ],
@@ -230,19 +212,18 @@
    "\"required\": false,",
    "\"locked\": false,",
    "\"display\": \"select\",",
-   "\"hierarchical\": false,",
-   "\"max_depth\": 0,",
    "\"choices\": [",
       "[",
-      "\"${3:value 1}\",",
-      "\"${4:Label 1}\"",
+      "  \"${3:value 1}\",",
+      "  \"${4:Label 1}\"",
       "],",
       "[",
-        "\"${5:value 2}\",",
-        "\"${6:Label 2}\"",
+        "  \"${5:value 2}\",",
+        "  \"${6:Label 2}\"",
       "]",
    "],",
    "\"type\": \"choice\",",
+   "\"placerholder\": \"\",",
    "\"default\": null }"
     ],
     "description": "HubSpot Custom Module: Choice Field"
@@ -257,9 +238,8 @@
    "\"sortable\": false,",
    "\"required\": false,",
    "\"locked\": false,",
-   "\"hierarchical\": false,",
-   "\"max_depth\": 0,",
    "\"type\": \"blog\",",
+   "\"placeholder\": \"\",",
    "\"default\": null }"
     ],
     "description": "HubSpot Custom Module: Blog Field"
@@ -274,12 +254,10 @@
    "\"sortable\": false,",
    "\"required\": false,",
    "\"locked\": false,",
-   "\"hierarchical\": false,",
-   "\"max_depth\": 0,",
    "\"type\": \"color\",",
    "\"default\": {",
-        "\"color\": \"${3:#ffffff\"},",
-        "\"opacity\": ${4:100} } }"
+        "  \"color\": \"${3:#ffffff\"},",
+        "  \"opacity\": ${4:100} } }"
     ],
     "description": "HubSpot Custom Module: Color Field"
   },
@@ -293,8 +271,6 @@
      "\"sortable\": false,",
      "\"required\": false,",
      "\"locked\": false,",
-     "\"hierarchical\": false,",
-     "\"max_depth\": 0,",
      "\"type\": \"cta\",",
      "\"default\": null }"
     ],
@@ -310,9 +286,8 @@
      "\"sortable\": false,",
      "\"required\": false,",
      "\"locked\": false,",
-     "\"hierarchical\": false,",
-     "\"max_depth\": 0,",
      "\"type\": \"email\",",
+     "\"placeholder\": \"\",",
      "\"default\": null }"
     ],
     "description": "HubSpot Custom Module: Email Field"
@@ -328,8 +303,6 @@
      "\"sortable\": false,",
      "\"required\": false,",
      "\"locked\": false,",
-     "\"hierarchical\": false,",
-     "\"max_depth\": 0,",
      "\"type\": \"file\",",
      "\"default\": null }"
     ],
@@ -345,9 +318,8 @@
      "\"sortable\": false,",
      "\"required\": false,",
      "\"locked\": false,",
-     "\"hierarchical\": false,",
-     "\"max_depth\": 0,",
      "\"type\": \"followupemail\",",
+     "\"placeholder\": \"\",",
      "\"default\": null }"
     ],
     "description": "HubSpot Custom Module: Followup Email"
@@ -362,8 +334,6 @@
      "\"sortable\": false,",
      "\"required\": false,",
      "\"locked\": false,",
-     "\"hierarchical\": false,",
-     "\"max_depth\": 0,",
      "\"type\": \"form\",",
      "\"default\": {",
      "  \"response_type\": \"inline\",",
@@ -381,9 +351,8 @@
      "\"sortable\": false,",
      "\"required\": false,",
      "\"locked\": false,",
-     "\"hierarchical\": false,",
-     "\"max_depth\": 0,",
      "\"type\": \"hubdbtable\",",
+     "\"placeholder\": \"\",",
      "\"default\": null }"
     ],
     "description": "HubSpot Custom Module: HubDB Table"
@@ -398,8 +367,6 @@
      "\"sortable\": false,",
      "\"required\": false,",
      "\"locked\": false,",
-     "\"hierarchical\": false,",
-     "\"max_depth\": 0,",
      "\"type\": \"icon\",",
      "\"default\": {} }"
     ],
@@ -415,8 +382,6 @@
      "\"sortable\": false,",
      "\"required\": false,",
      "\"locked\": false,",
-     "\"hierarchical\": false,",
-     "\"max_depth\": 0,",
      "\"resizable\": true,",
      "\"type\": \"image\",",
      "\"default\": {",
@@ -435,8 +400,6 @@
      "\"sortable\": false,",
      "\"required\": false,",
      "\"locked\": false,",
-     "\"hierarchical\": false,",
-     "\"max_depth\": 0,",
      "\"resizable\": true,",
      "\"type\": \"logo\",",
      "\"default\": {",
@@ -456,9 +419,8 @@
      "\"sortable\": false,",
      "\"required\": false,",
      "\"locked\": false,",
-     "\"hierarchical\": false,",
-     "\"max_depth\": 0,",
      "\"type\": \"menu\",",
+     "\"placeholder\": \"\",",
      "\"default\": null }"
     ],
     "description": "HubSpot Custom Module: Menu Field"
@@ -473,9 +435,8 @@
      "\"sortable\": false,",
      "\"required\": false,",
      "\"locked\": false,",
-     "\"hierarchical\": false,",
-     "\"max_depth\": 0,",
      "\"type\": \"page\",",
+     "\"placeholder\": \"\",",
      "\"default\": null }"
     ],
     "description": "HubSpot Custom Module: Page Field"
@@ -490,10 +451,9 @@
      "\"sortable\": false,",
      "\"required\": false,",
      "\"locked\": false,",
-     "\"hierarchical\": false,",
-     "\"max_depth\": 0,",
      "\"tag_value\": \"SLUG\",",
      "\"type\": \"tag\",",
+     "\"placeholder\": \"\",",
      "\"default\": null }"
     ],
     "description": "HubSpot Custom Module: Tag Field"
@@ -508,9 +468,8 @@
      "\"sortable\": false,",
      "\"required\": false,",
      "\"locked\": false,",
-     "\"hierarchical\": false,",
-     "\"max_depth\": 0,",
      "\"type\": \"workflow\",",
+     "\"placeholder\": \"\",",
      "\"default\": null }"
     ],
     "description": "HubSpot Custom Module: Workflow Field"


### PR DESCRIPTION
Does some cleanup of `hubl_custom_module_fields.json`.

`hierarchichal` and `max_depth` are deprecated fields and we shouldn't be generating them. There are a few other small property changes, and some spacing fix-ups here.

@williamspiro 